### PR TITLE
feat: Core blockchain query CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+ONESOURCE_API_KEY=your_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,117 @@
 # onesource-cli
-A sandbox to experiment with a CLI for OneSource
+
+CLI for querying OneSource blockchain data. Four commands, two deps, native `fetch()`.
+
+## Install
+
+```bash
+git clone git@github.com:blockparty-global/onesource-cli.git
+cd onesource-cli
+npm install
+npm run build
+```
+
+To make the `onesource` command available globally:
+
+```bash
+npm link
+```
+
+## Configuration
+
+Set your API key as an environment variable:
+
+```bash
+export ONESOURCE_API_KEY=your_key_here
+```
+
+Also accepts `MACH10_API_KEY`. Optionally override the endpoint:
+
+```bash
+export ONESOURCE_API_ENDPOINT=https://api-sre-dash.onesource.io/graphql  # default
+```
+
+## Usage
+
+### block
+
+Fetch a single block by number or hash.
+
+```bash
+onesource block 20000000
+onesource block --hash 0xd24fd73f794058a3807db926d8898c6481e902b7edb91ce0d479d6760f276183
+onesource block 20000000 --yaml
+```
+
+### blocks
+
+List blocks with optional filters and pagination.
+
+```bash
+onesource blocks --first 5
+onesource blocks --first 5 --order-by TIMESTAMP --order DESC
+onesource blocks --number-min 20000000 --number-max 20000010
+```
+
+Options:
+
+| Flag | Description |
+|------|-------------|
+| `--number-min <n>` | Minimum block number |
+| `--number-max <n>` | Maximum block number |
+| `--first <n>` | Page size (default: 10) |
+| `--after <cursor>` | Pagination cursor |
+| `--order-by <field>` | NUMBER, TIMESTAMP, TRANSACTION_COUNT, SIZE, GAS_USED |
+| `--order <dir>` | ASC or DESC |
+
+### transaction
+
+Fetch a single transaction by hash.
+
+```bash
+onesource transaction 0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060
+```
+
+### transactions
+
+List transactions with optional filters and pagination.
+
+```bash
+onesource transactions --first 5
+onesource transactions --from 0xa1e4380a3b1f749673e270229993ee55f35663b4
+onesource transactions --block-min 20000000 --block-max 20000100
+onesource transactions --status SUCCESS --order-by VALUE --order DESC
+```
+
+Options:
+
+| Flag | Description |
+|------|-------------|
+| `--from <address>` | Filter by sender |
+| `--to <address>` | Filter by recipient |
+| `--block-min <n>` | Minimum block number |
+| `--block-max <n>` | Maximum block number |
+| `--status <s>` | SUCCESS or FAILED |
+| `--first <n>` | Page size (default: 10) |
+| `--after <cursor>` | Pagination cursor |
+| `--order-by <field>` | BLOCK_NUMBER, TIMESTAMP, VALUE, HASH, GAS, NONCE |
+| `--order <dir>` | ASC or DESC |
+
+## Output
+
+JSON by default (standard GraphQL `{ data: { ... } }` envelope). Add `--yaml` to any command for YAML output.
+
+Pipe-friendly — no colors or spinners:
+
+```bash
+onesource block 20000000 | jq '.data.block.gasUsed'
+onesource transactions --first 3 | jq '.data.transactions.entries[].hash'
+```
+
+## Development
+
+```bash
+npx tsx src/cli.ts block 20000000   # run without building
+npm run build                        # compile to dist/
+node dist/cli.js block 20000000      # run compiled
+```

--- a/docs/plans/2026-03-02-feat-core-blockchain-query-cli-plan.md
+++ b/docs/plans/2026-03-02-feat-core-blockchain-query-cli-plan.md
@@ -48,16 +48,16 @@ onesource block 20000000 | jq '.data.block.gasUsed'
 
 ## Acceptance Criteria
 
-- [ ] `onesource transaction <hash>` — fetches single transaction by hash
-- [ ] `onesource transactions` — lists transactions with filter/pagination flags
-- [ ] `onesource block <number>` — fetches single block by number (or `--hash`)
-- [ ] `onesource blocks` — lists blocks with filter/pagination flags
-- [ ] JSON output by default (standard GraphQL `{ data: { ... } }` envelope)
-- [ ] `--yaml` flag converts output to YAML
-- [ ] API key read from `ONESOURCE_API_KEY` env var (falls back to `MACH10_API_KEY`)
-- [ ] Clear error messages for missing API key, network failures, GraphQL errors
-- [ ] `onesource --help` and per-command help
-- [ ] Pipe-friendly: no color/spinners by default, clean stdout for `jq`
+- [x] `onesource transaction <hash>` — fetches single transaction by hash
+- [x] `onesource transactions` — lists transactions with filter/pagination flags
+- [x] `onesource block <number>` — fetches single block by number (or `--hash`)
+- [x] `onesource blocks` — lists blocks with filter/pagination flags
+- [x] JSON output by default (standard GraphQL `{ data: { ... } }` envelope)
+- [x] `--yaml` flag converts output to YAML
+- [x] API key read from `ONESOURCE_API_KEY` env var (falls back to `MACH10_API_KEY`)
+- [x] Clear error messages for missing API key, network failures, GraphQL errors
+- [x] `onesource --help` and per-command help
+- [x] Pipe-friendly: no color/spinners by default, clean stdout for `jq`
 
 ## MVP
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,624 @@
+{
+  "name": "onesource-cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "onesource-cli",
+      "version": "0.1.0",
+      "dependencies": {
+        "commander": "^13.0.0",
+        "yaml": "^2.7.0"
+      },
+      "bin": {
+        "onesource": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
+      "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "onesource-cli",
+  "version": "0.1.0",
+  "description": "CLI for querying OneSource blockchain data",
+  "type": "module",
+  "bin": {
+    "onesource": "./dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx src/cli.ts",
+    "start": "node dist/cli.js"
+  },
+  "dependencies": {
+    "commander": "^13.0.0",
+    "yaml": "^2.7.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { program } from 'commander';
+import { registerBlockCommands } from './commands/block.js';
+import { registerTransactionCommands } from './commands/transaction.js';
+
+program
+  .name('onesource')
+  .description('CLI for querying OneSource blockchain data')
+  .version('0.1.0');
+
+registerBlockCommands(program);
+registerTransactionCommands(program);
+
+program.parse();

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,43 @@
+const ENDPOINT = process.env.ONESOURCE_API_ENDPOINT
+  || 'https://api-sre-dash.onesource.io/graphql';
+
+function getApiKey(): string {
+  const key = process.env.ONESOURCE_API_KEY || process.env.MACH10_API_KEY;
+  if (!key) {
+    console.error('Error: ONESOURCE_API_KEY environment variable is required.');
+    console.error('Set it with: export ONESOURCE_API_KEY=your_key_here');
+    process.exit(1);
+  }
+  return key;
+}
+
+export async function query(
+  gql: string,
+  variables?: Record<string, unknown>
+): Promise<unknown> {
+  const res = await fetch(ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-bp-token': getApiKey(),
+    },
+    body: JSON.stringify({ query: gql, variables }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    console.error(`HTTP ${res.status}: ${res.statusText}`);
+    if (body) console.error(body);
+    process.exit(1);
+  }
+
+  const json = await res.json();
+
+  if (json.errors) {
+    const messages = json.errors.map((e: { message: string }) => e.message).join('\n');
+    console.error(`GraphQL Error:\n${messages}`);
+    process.exit(1);
+  }
+
+  return json;
+}

--- a/src/commands/block.ts
+++ b/src/commands/block.ts
@@ -1,0 +1,111 @@
+import { Command } from 'commander';
+import { query } from '../client.js';
+import { format } from '../output.js';
+
+const GET_BLOCK = `
+  query GetBlock($number: BlockNumber, $hash: BlockHash) {
+    block(number: $number, hash: $hash) {
+      number
+      hash
+      timestamp
+      transactionCount
+      gasUsed
+      gasLimit
+      difficulty
+      size
+      confirmations
+    }
+  }
+`;
+
+const GET_BLOCKS = `
+  query GetBlocks(
+    $first: Int
+    $after: Cursor
+    $where: BlockFilter
+    $orderBy: BlockOrderBy
+    $orderDirection: OrderDirection
+  ) {
+    blocks(
+      first: $first
+      after: $after
+      where: $where
+      orderBy: $orderBy
+      orderDirection: $orderDirection
+    ) {
+      totalCount
+      pageInfo { hasNextPage endCursor count }
+      entries {
+        number
+        hash
+        timestamp
+        transactionCount
+        gasUsed
+        gasLimit
+        difficulty
+        size
+        confirmations
+      }
+    }
+  }
+`;
+
+export function registerBlockCommands(program: Command) {
+  program
+    .command('block [number]')
+    .description('Get a single block by number or hash')
+    .option('--hash <hash>', 'Look up block by hash instead of number')
+    .option('--yaml', 'Output as YAML instead of JSON')
+    .action(async (number: string | undefined, opts: { hash?: string; yaml?: boolean }) => {
+      const variables: Record<string, unknown> = {};
+      if (opts.hash) {
+        variables.hash = opts.hash;
+      } else if (number) {
+        variables.number = number;
+      } else {
+        console.error('Error: provide a block number or --hash');
+        process.exit(1);
+      }
+      const result = await query(GET_BLOCK, variables);
+      console.log(format(result, !!opts.yaml));
+    });
+
+  program
+    .command('blocks')
+    .description('List blocks with optional filters')
+    .option('--number-min <n>', 'Minimum block number')
+    .option('--number-max <n>', 'Maximum block number')
+    .option('--first <n>', 'Page size', '10')
+    .option('--after <cursor>', 'Pagination cursor')
+    .option('--order-by <field>', 'Sort field (NUMBER, TIMESTAMP, TRANSACTION_COUNT, SIZE, GAS_USED)')
+    .option('--order <dir>', 'Sort direction (ASC, DESC)')
+    .option('--yaml', 'Output as YAML instead of JSON')
+    .action(async (opts: {
+      numberMin?: string;
+      numberMax?: string;
+      first: string;
+      after?: string;
+      orderBy?: string;
+      order?: string;
+      yaml?: boolean;
+    }) => {
+      const variables: Record<string, unknown> = {
+        first: parseInt(opts.first, 10),
+      };
+      if (opts.after) variables.after = opts.after;
+      if (opts.orderBy) variables.orderBy = opts.orderBy;
+      if (opts.order) variables.orderDirection = opts.order;
+
+      const where: Record<string, unknown> = {};
+      if (opts.numberMin || opts.numberMax) {
+        const range: Record<string, number> = {};
+        if (opts.numberMin) range.gte = parseInt(opts.numberMin, 10);
+        if (opts.numberMax) range.lte = parseInt(opts.numberMax, 10);
+        where.number = range;
+      }
+      if (Object.keys(where).length > 0) variables.where = where;
+
+      const result = await query(GET_BLOCKS, variables);
+      console.log(format(result, !!opts.yaml));
+    });
+}

--- a/src/commands/transaction.ts
+++ b/src/commands/transaction.ts
@@ -1,0 +1,120 @@
+import { Command } from 'commander';
+import { query } from '../client.js';
+import { format } from '../output.js';
+
+const GET_TRANSACTION = `
+  query GetTransaction($hash: TransactionHash!) {
+    transaction(hash: $hash) {
+      hash
+      timestamp
+      from { address }
+      to { address }
+      value { raw formatted decimals }
+      gas { limit price used feeCap tipCap }
+      nonce
+      confirmations
+      status
+      block { number hash timestamp }
+      contractCreated { address name }
+    }
+  }
+`;
+
+const GET_TRANSACTIONS = `
+  query GetTransactions(
+    $first: Int
+    $after: Cursor
+    $where: TransactionFilter
+    $orderBy: TransactionOrderBy
+    $orderDirection: OrderDirection
+  ) {
+    transactions(
+      first: $first
+      after: $after
+      where: $where
+      orderBy: $orderBy
+      orderDirection: $orderDirection
+    ) {
+      totalCount
+      pageInfo { hasNextPage endCursor count }
+      entries {
+        hash
+        timestamp
+        from { address }
+        to { address }
+        value { raw formatted decimals }
+        gas { limit price used }
+        nonce
+        confirmations
+        status
+        block { number }
+      }
+      stats {
+        totalCount
+        totalValue { raw formatted decimals }
+        averageGasPrice
+        averageGasUsed
+        uniqueAddresses
+      }
+    }
+  }
+`;
+
+export function registerTransactionCommands(program: Command) {
+  program
+    .command('transaction <hash>')
+    .description('Get a single transaction by hash')
+    .option('--yaml', 'Output as YAML instead of JSON')
+    .action(async (hash: string, opts: { yaml?: boolean }) => {
+      const result = await query(GET_TRANSACTION, { hash });
+      console.log(format(result, !!opts.yaml));
+    });
+
+  program
+    .command('transactions')
+    .description('List transactions with optional filters')
+    .option('--from <address>', 'Filter by sender address')
+    .option('--to <address>', 'Filter by recipient address')
+    .option('--block-min <n>', 'Minimum block number')
+    .option('--block-max <n>', 'Maximum block number')
+    .option('--status <status>', 'Filter by status (SUCCESS, FAILED)')
+    .option('--first <n>', 'Page size', '10')
+    .option('--after <cursor>', 'Pagination cursor')
+    .option('--order-by <field>', 'Sort field (BLOCK_NUMBER, TIMESTAMP, VALUE, HASH, GAS, NONCE)')
+    .option('--order <dir>', 'Sort direction (ASC, DESC)')
+    .option('--yaml', 'Output as YAML instead of JSON')
+    .action(async (opts: {
+      from?: string;
+      to?: string;
+      blockMin?: string;
+      blockMax?: string;
+      status?: string;
+      first: string;
+      after?: string;
+      orderBy?: string;
+      order?: string;
+      yaml?: boolean;
+    }) => {
+      const variables: Record<string, unknown> = {
+        first: parseInt(opts.first, 10),
+      };
+      if (opts.after) variables.after = opts.after;
+      if (opts.orderBy) variables.orderBy = opts.orderBy;
+      if (opts.order) variables.orderDirection = opts.order;
+
+      const where: Record<string, unknown> = {};
+      if (opts.from) where.from = opts.from;
+      if (opts.to) where.to = opts.to;
+      if (opts.status) where.status = opts.status;
+      if (opts.blockMin || opts.blockMax) {
+        const range: Record<string, number> = {};
+        if (opts.blockMin) range.gte = parseInt(opts.blockMin, 10);
+        if (opts.blockMax) range.lte = parseInt(opts.blockMax, 10);
+        where.blockNumber = range;
+      }
+      if (Object.keys(where).length > 0) variables.where = where;
+
+      const result = await query(GET_TRANSACTIONS, variables);
+      console.log(format(result, !!opts.yaml));
+    });
+}

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,0 +1,5 @@
+import { stringify } from 'yaml';
+
+export function format(data: unknown, useYaml: boolean): string {
+  return useYaml ? stringify(data) : JSON.stringify(data, null, 2);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Implements `onesource` CLI with 4 subcommands: `block`, `blocks`, `transaction`, `transactions`
- Queries the OneSource GraphQL API (`api-sre-dash.onesource.io`) using native `fetch()` — no heavy deps
- JSON output by default (standard `{ data: { ... } }` envelope), `--yaml` flag for YAML
- Filter and pagination flags on list commands (`--from`, `--to`, `--first`, `--order-by`, etc.)
- API key via `ONESOURCE_API_KEY` env var (falls back to `MACH10_API_KEY`)

## Usage

```bash
export ONESOURCE_API_KEY=your_key

onesource block 20000000
onesource block 20000000 --yaml
onesource block 20000000 | jq '.data.block.gasUsed'
onesource blocks --first 5 --order-by TIMESTAMP --order DESC
onesource transaction 0x5c504ed...
onesource transactions --from 0x... --first 10
```

## Test plan

- [x] `onesource block 20000000` returns correct block data
- [x] `onesource blocks --first 3 --order-by NUMBER --order DESC` returns paginated results
- [x] `onesource transaction <known_hash>` returns correct tx data
- [x] `onesource transactions --first 2` returns paginated results with stats
- [x] `--yaml` flag produces valid YAML output
- [x] `--help` and per-command help display correctly
- [x] Missing block arg produces clear error
- [x] All queries validated against live API

🤖 Generated with [Claude Code](https://claude.com/claude-code)