### PR TITLE
feat: add endpoint switching and NFT query command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # onesource-cli
 
-CLI for querying OneSource blockchain data. Four commands, two deps, native `fetch()`.
+CLI for querying OneSource blockchain data. Supports multiple networks, five commands, two deps, native `fetch()`.
 
 ## Install
 
@@ -25,17 +25,47 @@ Set your API key as an environment variable:
 export ONESOURCE_API_KEY=your_key_here
 ```
 
-Also accepts `MACH10_API_KEY`. Optionally override the endpoint:
+Also accepts `MACH10_API_KEY`.
+
+## Endpoints
+
+The CLI supports multiple OneSource API endpoints. Switch between them with the `endpoint` command:
 
 ```bash
-export ONESOURCE_API_ENDPOINT=https://api-sre-dash.onesource.io/graphql  # default
+onesource endpoint                  # show current endpoint and list available
+onesource endpoint ethereum         # switch to Ethereum mainnet
+onesource endpoint blockticity      # switch to Blockticity (BTIC) Avalanche L1 subnet
 ```
+
+| Name | URL | Description |
+|------|-----|-------------|
+| `ethereum` | `https://api-sre-dash.onesource.io/graphql` | Ethereum mainnet (default) |
+| `blockticity` | `https://api-blockticity.onesource.io/graphql` | Blockticity (BTIC) Avalanche L1 subnet |
+
+You can also set a custom endpoint URL directly:
+
+```bash
+onesource endpoint https://custom.example.com/graphql
+```
+
+The selection persists in `~/.onesource/config.json`. The `ONESOURCE_API_ENDPOINT` environment variable takes priority over saved config if set.
 
 ## Usage
 
+### endpoint
+
+Show or set the active API endpoint.
+
+```bash
+onesource endpoint                  # show current and list all
+onesource endpoint ethereum         # switch to Ethereum
+onesource endpoint blockticity      # switch to Blockticity
+onesource endpoint --list           # same as no args
+```
+
 ### block
 
-Fetch a single block by number or hash.
+Fetch a single block by number or hash. (Ethereum endpoint)
 
 ```bash
 onesource block 20000000
@@ -45,7 +75,7 @@ onesource block 20000000 --yaml
 
 ### blocks
 
-List blocks with optional filters and pagination.
+List blocks with optional filters and pagination. (Ethereum endpoint)
 
 ```bash
 onesource blocks --first 5
@@ -66,7 +96,7 @@ Options:
 
 ### transaction
 
-Fetch a single transaction by hash.
+Fetch a single transaction by hash. (Ethereum endpoint)
 
 ```bash
 onesource transaction 0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060
@@ -74,7 +104,7 @@ onesource transaction 0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfb
 
 ### transactions
 
-List transactions with optional filters and pagination.
+List transactions with optional filters and pagination. (Ethereum endpoint)
 
 ```bash
 onesource transactions --first 5
@@ -97,6 +127,24 @@ Options:
 | `--order-by <field>` | BLOCK_NUMBER, TIMESTAMP, VALUE, HASH, GAS, NONCE |
 | `--order <dir>` | ASC or DESC |
 
+### nft
+
+Fetch NFT metadata by contract address and token ID. (Blockticity endpoint)
+
+```bash
+onesource endpoint blockticity
+onesource nft 0x7D1955F814f25Ec2065C01B9bFc0AcC29B3f2926 842909
+onesource nft 0x7D1955F814f25Ec2065C01B9bFc0AcC29B3f2926 862909 --yaml
+onesource nft 0x7D1955F814f25Ec2065C01B9bFc0AcC29B3f2926 842909 --network BTIC
+```
+
+Options:
+
+| Flag | Description |
+|------|-------------|
+| `--network <name>` | Network name (default: BTIC) |
+| `--yaml` | Output as YAML |
+
 ## Output
 
 JSON by default (standard GraphQL `{ data: { ... } }` envelope). Add `--yaml` to any command for YAML output.
@@ -106,6 +154,7 @@ Pipe-friendly — no colors or spinners:
 ```bash
 onesource block 20000000 | jq '.data.block.gasUsed'
 onesource transactions --first 3 | jq '.data.transactions.entries[].hash'
+onesource nft 0x7D1955F814f25Ec2065C01B9bFc0AcC29B3f2926 842909 | jq '.data.nft.metadata.attributes'
 ```
 
 ## Development

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,13 +2,17 @@
 import { program } from 'commander';
 import { registerBlockCommands } from './commands/block.js';
 import { registerTransactionCommands } from './commands/transaction.js';
+import { registerEndpointCommands } from './commands/endpoint.js';
+import { registerNftCommands } from './commands/nft.js';
 
 program
   .name('onesource')
   .description('CLI for querying OneSource blockchain data')
   .version('0.1.0');
 
+registerEndpointCommands(program);
 registerBlockCommands(program);
 registerTransactionCommands(program);
+registerNftCommands(program);
 
 program.parse();

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,4 @@
-const ENDPOINT = process.env.ONESOURCE_API_ENDPOINT
-  || 'https://api-sre-dash.onesource.io/graphql';
+import { resolveEndpointUrl } from './endpoints.js';
 
 function getApiKey(): string {
   const key = process.env.ONESOURCE_API_KEY || process.env.MACH10_API_KEY;
@@ -15,7 +14,8 @@ export async function query(
   gql: string,
   variables?: Record<string, unknown>
 ): Promise<unknown> {
-  const res = await fetch(ENDPOINT, {
+  const endpoint = resolveEndpointUrl();
+  const res = await fetch(endpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/commands/endpoint.ts
+++ b/src/commands/endpoint.ts
@@ -1,0 +1,60 @@
+import { Command } from 'commander';
+import {
+  KNOWN_ENDPOINTS,
+  DEFAULT_ENDPOINT,
+  getActiveEndpointName,
+  resolveEndpointUrl,
+  setEndpoint,
+} from '../endpoints.js';
+
+export function registerEndpointCommands(parent: Command): void {
+  const cmd = parent
+    .command('endpoint [name]')
+    .description('Show or set the active API endpoint')
+    .option('--list', 'List all known endpoints')
+    .action((name: string | undefined, opts: { list?: boolean }) => {
+      if (opts.list || !name) {
+        showEndpoints();
+        return;
+      }
+
+      // Validate: known name or URL
+      const isKnown = name in KNOWN_ENDPOINTS;
+      const isUrl = name.startsWith('http://') || name.startsWith('https://');
+
+      if (!isKnown && !isUrl) {
+        const names = Object.keys(KNOWN_ENDPOINTS).join(', ');
+        console.error(`Unknown endpoint: ${name}`);
+        console.error(`Known endpoints: ${names}`);
+        console.error('Or provide a full URL (https://...)');
+        process.exit(1);
+      }
+
+      setEndpoint(name);
+      const url = isKnown ? KNOWN_ENDPOINTS[name].url : name;
+      console.log(`Endpoint set to: ${name}`);
+      console.log(`URL: ${url}`);
+    });
+}
+
+function showEndpoints(): void {
+  const active = getActiveEndpointName();
+  const activeUrl = resolveEndpointUrl();
+
+  console.log(`Active: ${active}`);
+  console.log(`URL:    ${activeUrl}`);
+  console.log();
+  console.log('Available endpoints:');
+
+  for (const [name, info] of Object.entries(KNOWN_ENDPOINTS)) {
+    const marker = name === active ? ' (active)' : '';
+    console.log(`  ${name}${marker}`);
+    console.log(`    ${info.description}`);
+    console.log(`    ${info.url}`);
+  }
+
+  if (process.env.ONESOURCE_API_ENDPOINT) {
+    console.log();
+    console.log(`Note: ONESOURCE_API_ENDPOINT env var is set and takes priority.`);
+  }
+}

--- a/src/commands/nft.ts
+++ b/src/commands/nft.ts
@@ -1,0 +1,45 @@
+import { Command } from 'commander';
+import * as client from '../client.js';
+import { format } from '../output.js';
+
+const GET_NFT = `
+query GetNFT($tokenId: String!, $contract: String!, $network: Network) {
+  nft(tokenId: $tokenId, contract: $contract, network: $network) {
+    name
+    description
+    network
+    tokenId
+    contractAddress
+    transactionHash
+    metadata {
+      description
+      name
+      externalUrl
+      attributes {
+        traitType
+        value
+      }
+    }
+    blockNumber
+    tokenUri
+  }
+}
+`;
+
+export function registerNftCommands(parent: Command): void {
+  parent
+    .command('nft <contract> <tokenId>')
+    .description('Get NFT metadata by contract address and token ID')
+    .option('--network <network>', 'Network name (e.g. BTIC)', 'BTIC')
+    .option('--yaml', 'Output as YAML instead of JSON')
+    .action(async (contract: string, tokenId: string, opts: { network: string; yaml?: boolean }) => {
+      const variables = {
+        contract,
+        tokenId,
+        network: opts.network,
+      };
+
+      const result = await client.query(GET_NFT, variables);
+      console.log(format(result, !!opts.yaml));
+    });
+}

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -1,0 +1,56 @@
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const KNOWN_ENDPOINTS: Record<string, { url: string; description: string }> = {
+  ethereum: {
+    url: 'https://api-sre-dash.onesource.io/graphql',
+    description: 'Ethereum mainnet (default)',
+  },
+  blockticity: {
+    url: 'https://api-blockticity.onesource.io/graphql',
+    description: 'Blockticity (BTIC) Avalanche L1 subnet',
+  },
+};
+
+export const DEFAULT_ENDPOINT = 'ethereum';
+
+const CONFIG_DIR = join(homedir(), '.onesource');
+const CONFIG_FILE = join(CONFIG_DIR, 'config.json');
+
+interface Config {
+  endpoint?: string; // name or URL
+}
+
+function readConfig(): Config {
+  try {
+    return JSON.parse(readFileSync(CONFIG_FILE, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeConfig(config: Config): void {
+  mkdirSync(CONFIG_DIR, { recursive: true });
+  writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2) + '\n');
+}
+
+export function getActiveEndpointName(): string {
+  return process.env.ONESOURCE_API_ENDPOINT
+    ? 'custom (env)'
+    : readConfig().endpoint ?? DEFAULT_ENDPOINT;
+}
+
+export function resolveEndpointUrl(): string {
+  if (process.env.ONESOURCE_API_ENDPOINT) {
+    return process.env.ONESOURCE_API_ENDPOINT;
+  }
+
+  const configured = readConfig().endpoint ?? DEFAULT_ENDPOINT;
+  const known = KNOWN_ENDPOINTS[configured];
+  return known ? known.url : configured; // treat as raw URL if not a known name
+}
+
+export function setEndpoint(nameOrUrl: string): void {
+  writeConfig({ ...readConfig(), endpoint: nameOrUrl });
+}


### PR DESCRIPTION
## Summary

- Adds `onesource endpoint` command to switch between Ethereum and Blockticity (BTIC Avalanche L1 subnet) APIs with persistent config at `~/.onesource/config.json`
- Adds `onesource nft` command to query NFT metadata by contract address and token ID from the Blockticity endpoint
- Updates README with endpoint and NFT documentation

Addresses #4.

## Smoke test results

| # | Command | Endpoint | Result |
|---|---------|----------|--------|
| 1 | `block 20000000` | Ethereum | Block #20000000, 134 txs |
| 2 | `blocks --first 3` | Ethereum | 3 latest blocks returned |
| 3 | `transaction 0x5c504...` | Ethereum | First-ever ETH transfer, 31337 wei |
| 4 | `transactions --first 3` | Ethereum | 3 transactions returned |
| 5 | `nft 0x7D19...2926 842909` | Blockticity | COA certificate with full metadata (GVE-00013880) |

All queries return valid data. Endpoint switching persists across commands and resets cleanly.

## Test plan

- [ ] Run `onesource endpoint` to verify default is ethereum
- [ ] Run `onesource endpoint blockticity` then `onesource endpoint` to verify switch
- [ ] Run `onesource nft 0x7D1955F814f25Ec2065C01B9bFc0AcC29B3f2926 842909` against blockticity
- [ ] Run `onesource endpoint ethereum` and verify block/transaction commands still work
- [ ] Test invalid endpoint name returns error with suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)