### PR TITLE
feat: add NFT query support for Ethereum endpoint

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -6,6 +6,7 @@ interface QueryOptions {
   timeout?: number;
   retries?: number;
   retryDelay?: number;
+  endpoint?: string;
 }
 
 function getApiKey(): string {
@@ -45,7 +46,7 @@ async function executeQuery<T>(
   variables?: GraphQLQueryVariables,
   options: QueryOptions = {}
 ): Promise<GraphQLResponse<T>> {
-  const endpoint = resolveEndpointUrl();
+  const endpoint = options.endpoint ?? resolveEndpointUrl();
   const { timeout = 30000 } = options; // 30 second default timeout
   
   const res = await fetchWithTimeout(endpoint, {

--- a/src/commands/nft.ts
+++ b/src/commands/nft.ts
@@ -2,9 +2,10 @@ import { Command } from 'commander';
 import { query } from '../client.js';
 import { format } from '../output.js';
 import { ValidationError, handleError } from '../errors.js';
-import type { NFTResponse, NFTOptions } from '../types.js';
+import { getActiveEndpointName } from '../endpoints.js';
+import type { NFTResponse, EthNFTResponse, NFTOptions } from '../types.js';
 
-const GET_NFT = `
+const GET_NFT_BLOCKTICITY = `
 query GetNFT($tokenId: String!, $contract: String!, $network: Network) {
   nft(tokenId: $tokenId, contract: $contract, network: $network) {
     name
@@ -28,11 +29,37 @@ query GetNFT($tokenId: String!, $contract: String!, $network: Network) {
 }
 `;
 
+const GET_NFT_ETHEREUM = `
+query GetNFT($tokenId: TokenId!, $contract: AddressString!) {
+  nft(tokenId: $tokenId, contract: $contract) {
+    name
+    tokenId
+    standard
+    contract {
+      address
+      name
+      symbol
+    }
+    metadata {
+      uri
+      name
+      description
+      image
+      externalUrl
+      attributes {
+        traitType
+        value
+      }
+    }
+  }
+}
+`;
+
 export function registerNftCommands(parent: Command): void {
   parent
     .command('nft <contract> <tokenId>')
     .description('Get NFT metadata by contract address and token ID')
-    .option('--network <network>', 'Network name (e.g. BTIC)', 'BTIC')
+    .option('--network <network>', 'Network name (for blockticity endpoint, e.g. BTIC)', 'BTIC')
     .option('--yaml', 'Output as YAML instead of JSON')
     .action(async (contract: string, tokenId: string, opts: NFTOptions & { network: string }) => {
       try {
@@ -43,14 +70,17 @@ export function registerNftCommands(parent: Command): void {
           throw new ValidationError('Token ID is required', 'tokenId');
         }
 
-        const variables = {
-          contract,
-          tokenId,
-          network: opts.network,
-        };
+        const endpoint = getActiveEndpointName();
 
-        const result = await query<NFTResponse['data']>(GET_NFT, variables);
-        console.log(format(result, !!opts.yaml));
+        if (endpoint === 'blockticity') {
+          const variables = { contract, tokenId, network: opts.network };
+          const result = await query<NFTResponse['data']>(GET_NFT_BLOCKTICITY, variables);
+          console.log(format(result, !!opts.yaml));
+        } else {
+          const variables = { contract, tokenId };
+          const result = await query<EthNFTResponse['data']>(GET_NFT_ETHEREUM, variables);
+          console.log(format(result, !!opts.yaml));
+        }
       } catch (error) {
         handleError(error);
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,12 +125,37 @@ export interface NFT {
   tokenUri?: string;
 }
 
+// Ethereum endpoint NFT types
+export interface EthNFTMetadata {
+  uri?: string;
+  name?: string;
+  description?: string;
+  image?: string;
+  externalUrl?: string;
+  attributes?: NFTAttribute[];
+}
+
+export interface EthNFTContract {
+  address: string;
+  name?: string;
+  symbol?: string;
+}
+
+export interface EthNFT {
+  name?: string;
+  tokenId: string;
+  standard: string;
+  contract: EthNFTContract;
+  metadata?: EthNFTMetadata;
+}
+
 // API Response types
 export type BlockResponse = GraphQLResponse<{ block: Block }>;
 export type BlocksListResponse = GraphQLResponse<{ blocks: BlocksResponse }>;
 export type TransactionResponse = GraphQLResponse<{ transaction: Transaction }>;
 export type TransactionsListResponse = GraphQLResponse<{ transactions: TransactionsResponse }>;
 export type NFTResponse = GraphQLResponse<{ nft: NFT }>;
+export type EthNFTResponse = GraphQLResponse<{ nft: EthNFT }>;
 
 // Command option types
 export interface CommonOptions {


### PR DESCRIPTION
## Summary
- The `nft` command now works on both the Ethereum and Blockticity endpoints
- Detects the active endpoint and sends the appropriate GraphQL query (different scalar types and response schema)
- Adds `endpoint` option to `QueryOptions` for per-query endpoint override
- Adds typed interfaces for the Ethereum NFT response (`EthNFT`, `EthNFTMetadata`, `EthNFTContract`)

## Test plan
- [x] All 59 existing tests pass
- [x] `onesource nft 0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D 1` returns BAYC #1 on ethereum endpoint
- [x] `onesource nft 0x3b3ee1931dc30c1957379fac9aba94d1c48a5405 52407` returns Foundation NFT on ethereum endpoint
- [x] `onesource nft 0x7D1955F814f25Ec2065C01B9bFc0AcC29B3f2926 842909` still works on blockticity endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)